### PR TITLE
Fail on Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,25 @@ The generate option allows you to control which generators get used for the spec
 
 The list of generator names you can use are: `constructor,from-validated-array,to-array,getters,withers`
 
+### Continuous Integration Setup
+
+If you are committing your struct gen changes directly in the repo, then you'll want to make sure that struct-gen was properly run and tested before any commit is merged into the mainline branch.
+
+In that case, you'll want to use the `--fail-on-changes` flag while running struct gen during your CI testing pipeline. This will fail with exit code 1 if any changes are detected which in most CI pipelines will fail the build ensuring that the developer submitting the patch has tested with the latest changes and didn't modify any of the generated files.
+
+Example:
+```yaml
+- composer struct-gen:generate --fail-on-changes
+```
+
+If you are generating the structs into an external file via the `generatedPath` option and are ignoring that file in your CVS, then you'll want to make sure to run struct-gen **before you run composer install**.
+
+```yaml
+- composer struct-gen:generate -vv
+# some point later
+- composer install --no-dev -o
+```
+
 ## Why use static generation?
 
 Most libraries for DTOs or structs are not IDE friendly and give access to helpful methods for a struct via runtime magic and reflection. Not only is there a slight performance hit with these methods, it's difficult to get typesafe while also working well with ides and static analysis tools.

--- a/src/Command/GenerateStructsCommand.php
+++ b/src/Command/GenerateStructsCommand.php
@@ -11,10 +11,10 @@ use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 use function Krak\StructGen\{
+    detectChangesInGeneratedStructsForFiles,
     generateStructsExternallyForFiles,
     generateStructsForFiles,
-    traversePhpFiles
-};
+    traversePhpFiles};
 
 final class GenerateStructsCommand extends BaseCommand
 {
@@ -30,6 +30,7 @@ final class GenerateStructsCommand extends BaseCommand
             ->setDescription('Generate struct info for any matching classes')
             ->addArgument('paths', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Path globs to search and list directories', $this->config->paths())
             ->addOption('generated-path', 'g', InputOption::VALUE_REQUIRED, 'If set, the file path to generate the structs into', $this->config->generatedPath())
+            ->addOption('fail-on-changes', 'f', InputOption::VALUE_NONE, 'Ensures no changes are detected on generated structs by exiting with a failure if changes are detected.')
             ->addOption('basic-traverse-files', 'b', InputOption::VALUE_NONE, 'By default, this command will use symfony finder to traverse the list of paths which support glob patterns. If you do not want to include symfony finder, you can use the basic traverse files feature.');
     }
 
@@ -37,6 +38,7 @@ final class GenerateStructsCommand extends BaseCommand
         $paths = $input->getArgument('paths') ?: $this->config->paths();
         $generatedPath = $input->getOption('generated-path');
         $basicTraverseFiles = $input->getOption('basic-traverse-files');
+        $failOnChanges = $input->getOption('fail-on-changes');
         $files = $basicTraverseFiles ? traversePhpFiles($paths) : (function() use ($paths) {
             $finder = new Finder();
             $finder->files()->name('*.php')->in($paths);
@@ -44,9 +46,11 @@ final class GenerateStructsCommand extends BaseCommand
         })();
 
         if ($generatedPath) {
-            generateStructsExternallyForFiles($files, $generatedPath, new ConsoleLogger($output));
+            $res = generateStructsExternallyForFiles($files, $generatedPath, new ConsoleLogger($output));
         } else {
-            generateStructsForFiles($files, new ConsoleLogger($output));
+            $res = generateStructsForFiles($files, new ConsoleLogger($output));
         }
+
+        return $failOnChanges && $res->hasChanges() ? 1 : 0;
     }
 }


### PR DESCRIPTION
- Added support to fail if any changes are detected.
- This is very useful for CI or git hook scripts that
  enforce that generated files aren't modified explicitly
  and that engineers are running struct-gen on the same version

Signed-off-by: RJ Garcia <ragboyjr@icloud.com>